### PR TITLE
Potential fix for code scanning alert no. 97: Unnecessary pass

### DIFF
--- a/test_line_171_simple.py
+++ b/test_line_171_simple.py
@@ -60,7 +60,6 @@ class TestLine171Simple:
         def track_join(*args, **kwargs):
             join_called[0] = True
             # Don't actually join, just mark it
-            pass
         
         server.thread.is_alive = force_alive
         server.thread.join = track_join


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/97](https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/97)

To fix the problem, remove the redundant `pass` statement from the `track_join` function while keeping the rest of the logic intact. In general, `pass` should be used only in blocks that would otherwise be empty (e.g., placeholder functions or classes); when there are already executable statements, the `pass` is unnecessary.

Concretely, in `test_line_171_simple.py`, within the `TestLine171Simple.test_line_171_direct_monkeypatch` method, edit the `track_join` function definition at lines 60–63. Delete the `pass` line and leave the comment and the state-tracking assignment as-is. No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
