### PR TITLE
Potential fix for code scanning alert no. 57: Variable defined multiple times

### DIFF
--- a/production_impl.py
+++ b/production_impl.py
@@ -155,9 +155,9 @@ class ElasticsearchSource(DataSource):
         pass
 
 
-class MySQLSink(DataSink):
-    """Production MySQL data sink with thread-safe operations"""
-    import threading
+
+
+
 
 
 class MySQLSink(DataSink):


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/57](https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/57)

In general, when the same variable (or class name) is defined multiple times in the same scope without any usage in between, the earlier definition is redundant and should be removed to avoid confusion and potential bugs. For class redefinitions in Python modules, the latter definition always wins.

Here, the best fix that preserves existing functionality is to delete the first, minimal `MySQLSink` class at lines 158–162 and keep the fully implemented `MySQLSink` starting at line 163. The first class does not define any behavior and is immediately shadowed by the second definition, and its only body statement is a local `import threading` that is unnecessary because `threading` is already imported at the module level on line 14. No additional methods or imports are needed; we are only removing the redundant class definition.

Concretely, in `production_impl.py`, remove the entire block:

```python
class MySQLSink(DataSink):
    """Production MySQL data sink with thread-safe operations"""
    import threading
```

leaving the subsequent `class MySQLSink(DataSink): """Production MySQL data sink with TRUE thread-safety"""` as the sole definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
