### PR TITLE
Potential fix for code scanning alert no. 58: Potentially uninitialized local variable

### DIFF
--- a/test_error_analyzer_100_percent.py
+++ b/test_error_analyzer_100_percent.py
@@ -223,6 +223,8 @@ class TestSimpleErrorAnalyzerAllMethods:
             json.loads("invalid json")
         except json.JSONDecodeError as e:
             error = e
+        else:
+            pytest.fail("Expected JSONDecodeError was not raised")
         
         context = {"operation": "parse_json"}
         result = analyzer.analyze_error(error, context)


### PR DESCRIPTION
Potential fix for [https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/58](https://github.com/kmcallorum/ElasticSearch_to_MySql/security/code-scanning/58)

In general, to fix a “potentially uninitialized local variable” in Python, ensure the variable is definitely assigned on all code paths before it is used. This can be done by assigning a default value before any conditional/try blocks, or by handling the “no-assignment” path explicitly (e.g., raising or failing the test).

For this specific case in `test_error_analyzer_100_percent.py`, the best fix without altering intended functionality is to keep the `try/except` that creates `error`, but add an `else` block that fails the test if `json.loads("invalid json")` does not raise `JSONDecodeError`. That guarantees that whenever execution reaches `analyzer.analyze_error(error, context)`, `error` is defined, and also makes the test stricter (it will fail explicitly instead of crashing with `UnboundLocalError`).

Concretely:
- In method `test_json_decode_help` (around lines 221–228), extend the `try/except` to:

```python
        try:
            json.loads("invalid json")
        except json.JSONDecodeError as e:
            error = e
        else:
            pytest.fail("Expected JSONDecodeError was not raised")
```

- This uses the already-imported `pytest` and does not require new imports or changes elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
