### PR TITLE
fix(security): scan GitHub Actions workflows with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        # 'actions' scans the workflow files themselves (e.g. GITHUB_TOKEN
+        # permissions); without it, Actions alerts are never re-evaluated.
+        language: [ 'python', 'actions' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## The security issue

One open code-scanning alert — **#98** `actions/missing-workflow-permissions` on `.github/workflows/test-updated.yml` (medium): the workflow's `GITHUB_TOKEN` wasn't restricted to least privilege.

## What's actually going on

The **code is already fixed**. That workflow got a `permissions: contents: read` block on 2026-07-13 (commit `3ae8559`). But the alert is still open and pinned to the old June commit, because:

- The alert comes from CodeQL's **`actions`** analysis (which scans `.github/workflows/*.yml`).
- `codeql.yml` only analyzes `language: ['python']`, so it **never re-evaluates the workflow files** — the alert can't auto-close, and no workflow security scanning happens going forward.

## Fix

Add `actions` to the CodeQL language matrix:

```yaml
language: [ 'python', 'actions' ]
```

On the next run, CodeQL re-scans the workflows, confirms the permissions block is present, **auto-closes #98**, and keeps scanning CI definitions for future issues (no build step needed for the `actions` language).

## Verification

- `codeql.yml` parses as valid YAML; matrix now `['python', 'actions']`.
- Both existing workflows already declare least-privilege permissions (`test-updated.yml`: top-level `contents: read`; `codeql.yml`: job-level), so the fresh `actions` scan should report **0** findings and resolve #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)