### PR TITLE
fix(security): pin codecov-action to a commit SHA (code-scanning #99)

### DIFF
--- a/.github/workflows/test-updated.yml
+++ b/.github/workflows/test-updated.yml
@@ -105,7 +105,7 @@ jobs:
         coverage report --skip-covered
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml


### PR DESCRIPTION
Follow-up to #37. Enabling `actions` CodeQL scanning closed the stale #98 and surfaced a real, previously-hidden finding: **#99** `actions/unpinned-tag` (medium).

## Issue

`.github/workflows/test-updated.yml` referenced the third-party `codecov/codecov-action@v7` — a **mutable tag**. If that tag were repointed (compromised maintainer, tag hijack), it would execute arbitrary code in CI with access to `CODECOV_TOKEN` and the workflow `GITHUB_TOKEN`.

## Fix

Pin to the immutable commit behind v7.0.0:

```yaml
uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
```

The `# v7.0.0` comment keeps it human-readable, and Dependabot updates SHA-pinned actions in place. First-party `actions/*` steps (checkout, setup-python, cache) aren't flagged and don't require pinning.

## Result

Resolves the last open code-scanning alert → repo goes to **0 open** across Dependabot + code scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)